### PR TITLE
VEE address version and chain id

### DIFF
--- a/src/main/scala/WalletGenerator.scala
+++ b/src/main/scala/WalletGenerator.scala
@@ -260,8 +260,8 @@ object WalletGenerator extends App {
 
   parser.parse(args, Config()) map { config =>
 
-    val addrVersion:Byte = 1
-    val chainId:Byte = if(config.testnet) 'T' else 'W'
+    val addrVersion:Byte = 5
+    val chainId:Byte = if(config.testnet) 'T' else 'M'
     val WalletFile = new java.io.File(WalletFileName)
     val walletFileName = WalletFile.getCanonicalPath
     val agentString = AgentString + (if(config.testnet) "/testnet" else "")


### PR DESCRIPTION
This sets the first two bytes of official VEE addresses.
It requires all VEE software (full node and wallets) to implement compatible address format according to this change.
Version byte is chosen as 0x5 so that the base58 address starts with letter 'A';
Chain ID byte is either 'M' for mainnet or 'T' for testnet;
Mainnet will then start with 'AR';
Testnet address will then start with either 'AT' or 'AU'.
