### PR TITLE
New salt for wallet encryption

### DIFF
--- a/src/main/scala/WalletGenerator.scala
+++ b/src/main/scala/WalletGenerator.scala
@@ -21,9 +21,9 @@ object WalletGenerator extends App {
 
   val AddressesCSVFileName = "addresses.csv"
   val WalletFileName = "wallet.dat"
-  val WalletVersion = "1.0rc1"
+  val WalletVersion = "1.0rc2"
   val AgentName = "VEE Wallet Generator"
-  val AgentVersion = "0.0.2"
+  val AgentVersion = "0.0.3"
   val AgentString = "VEE Wallet:" + WalletVersion + "/" + AgentName + ":" + AgentVersion
 
   val parser = new OptionParser[Config]("walletgenerator") {

--- a/src/main/scala/utils/JsonFileStorage.scala
+++ b/src/main/scala/utils/JsonFileStorage.scala
@@ -11,12 +11,12 @@ import scala.io.{BufferedSource, Source}
 
 object JsonFileStorage {
   private val encoding          = "UTF-8"
-  private val keySalt           = "0495c728-1614-41f6-8ac3-966c22b4a62d"
+  private val keySalt           = "0ba950e1-828b-4bae-9e06-faf078eb33ec"
   private val aes               = "AES"
   private val algorithm         = aes + "/ECB/PKCS5Padding"
   private val hashing           = "PBKDF2WithHmacSHA512"
   private val hashingIterations = 999999
-  private val keyLength         = 128
+  private val keyLength         = 256
 
   import java.security.NoSuchAlgorithmException
   import java.security.spec.InvalidKeySpecException


### PR DESCRIPTION
New salt for wallet encryption
Upgrade to AES-256 encryption
Set wallet specification version to 1.0rc2

This is considered a wallet format change (spec version 1.0rc2) and must be implemented on full node and Android cold wallet as well.
