### PR TITLE
Reduce hash rounds to improve cold wallet usability

### DIFF
--- a/src/main/scala/WalletGenerator.scala
+++ b/src/main/scala/WalletGenerator.scala
@@ -21,9 +21,9 @@ object WalletGenerator extends App {
 
   val AddressesCSVFileName = "addresses.csv"
   val WalletFileName = "wallet.dat"
-  val WalletVersion = "1.0rc2"
+  val WalletVersion = "1.0"
   val AgentName = "VEE Wallet Generator"
-  val AgentVersion = "0.1rc1"
+  val AgentVersion = "0.1.0"
   val AgentString = "VEE Wallet:" + WalletVersion + "/" + AgentName + ":" + AgentVersion
 
   val parser = new OptionParser[Config]("walletgenerator") {

--- a/src/main/scala/utils/JsonFileStorage.scala
+++ b/src/main/scala/utils/JsonFileStorage.scala
@@ -15,7 +15,7 @@ object JsonFileStorage {
   private val aes               = "AES"
   private val algorithm         = aes + "/ECB/PKCS5Padding"
   private val hashing           = "PBKDF2WithHmacSHA512"
-  private val hashingIterations = 999999
+  private val hashingIterations = 9999
   private val keyLength         = 256
 
   import java.security.NoSuchAlgorithmException


### PR DESCRIPTION
Wallet specification 1.0
Reduced hashing rounds to 9999. No apparent delay on cold wallet encryption/decryption.
This is considered a wallet format change. Need to be implemented on wallet-generator/vee-cold-android.